### PR TITLE
Introduce support for Microsoft SQL Server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,7 @@ libraryDependencies ++= {
     "mysql" % "mysql-connector-java" % "8.0.18", // TODO verify use of mysql-connector over explicit mariaDB connector instead
     "org.postgresql" % "postgresql" % "42.2.5",
     "org.xerial" % "sqlite-jdbc" % "3.25.2",
+    "com.microsoft.sqlserver" % "mssql-jdbc" % "9.2.1.jre11",
     "org.playframework.anorm" %% "anorm" % "2.6.4",
     "com.typesafe.play" %% "play-json" % "2.6.12",
     "com.pauldijou" %% "jwt-play" % "4.1.0",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -156,7 +156,7 @@ play.assets.cache."/public/app/"="no-cache"
 
 # Play evolutions
 # ~~~~~
-play.evolutions.useLocks=true
+play.evolutions.useLocks=false
 play.evolutions.autoApply=true
 
 # Play startup bindings

--- a/conf/evolutions/default/6.sql
+++ b/conf/evolutions/default/6.sql
@@ -18,6 +18,7 @@
 -- payload is currently limited to approx 5K!
 
 -- 2020-09-13: first encountered JSON payload with 5391B in production ==> double the field size
+-- 2021-03-11: MSSqlServer limits varchar to 8000, so shrink field size.
 create table input_event (
 	id varchar(36) not null primary key,
 	event_source varchar(50) not null,
@@ -25,7 +26,7 @@ create table input_event (
 	event_time timestamp not null,
 	user_info varchar(100),
 	input_id varchar(36) not null,
-	json_payload varchar(10000)
+	json_payload varchar(8000)
 );
 
 # --- !Downs


### PR DESCRIPTION
This PR allows us to use MS SQL Server with SMUI!!!

This was much less painful than I expected ;-).   I had to adjust down the size of the JSON payload to work with MSSqlServer, and the database locking I had to swap to false.   

I tried to add the MS SQL Server jar file via dockerfile, and mess with adding a classpath etc, but no joy, so I just added it to the project.

I know some people have strong opinions on Microsoft, however I'd like to merge this as a LOT of ecomm firms are .NET shops, and using MS SQL Server makes deployment of SMUI easier.   Especially at the non Super tech forward firms that maybe aren't all up on Docker.