### PR TITLE
Support evolution on MySQL 5.6

### DIFF
--- a/conf/evolutions/default/3.sql
+++ b/conf/evolutions/default/3.sql
@@ -10,8 +10,8 @@
 create table input_tag (
 	id varchar(36) not null primary key,
 	solr_index_id varchar(36),
-	property varchar(1000),
-	tag_value varchar(1000) not null,
+	property varchar(767),
+	tag_value varchar(767) not null,
 	exported int not null,
 	predefined int not null,
 	last_update timestamp not null


### PR DESCRIPTION
Mysql 5.6 didn't like a index being made with keys longer setting than 767.    So this supports that change.

