### PR TITLE
Remove the table name from the query structure.

### DIFF
--- a/app/models/SolrIndex.scala
+++ b/app/models/SolrIndex.scala
@@ -22,9 +22,9 @@ object SolrIndex {
 
   implicit val jsonFormat: OFormat[SolrIndex] = Json.format[SolrIndex]
 
-  val sqlParser: RowParser[SolrIndex] = get[SolrIndexId](s"$TABLE_NAME.id") ~
-    get[String](s"$TABLE_NAME.name") ~
-    get[String](s"$TABLE_NAME.description") map { case id ~ name ~ description =>
+  val sqlParser: RowParser[SolrIndex] = get[SolrIndexId](s"id") ~
+    get[String](s"name") ~
+    get[String](s"description") map { case id ~ name ~ description =>
     SolrIndex(id, name, description)
   }
 

--- a/app/models/SuggestedSolrField.scala
+++ b/app/models/SuggestedSolrField.scala
@@ -27,8 +27,8 @@ object SuggestedSolrField {
   val LAST_UPDATE = "last_update"
 
   val sqlParser: RowParser[SuggestedSolrField] = {
-    get[SuggestedSolrFieldId](s"$TABLE_NAME.$ID") ~
-      get[String](s"$TABLE_NAME.$NAME") map { case id ~ name =>
+    get[SuggestedSolrFieldId](s"$ID") ~
+      get[String](s"$NAME") map { case id ~ name =>
       SuggestedSolrField(id, name)
     }
   }

--- a/app/models/eventhistory/InputEvent.scala
+++ b/app/models/eventhistory/InputEvent.scala
@@ -75,13 +75,13 @@ object InputEvent extends Logging {
   val JSON_PAYLOAD = "json_payload"
 
   val sqlParser: RowParser[InputEvent] = {
-    get[InputEventId](s"$TABLE_NAME.$ID") ~
-      get[String](s"$TABLE_NAME.$EVENT_SOURCE") ~
-      get[Int](s"$TABLE_NAME.$EVENT_TYPE") ~
-      get[LocalDateTime](s"$TABLE_NAME.$EVENT_TIME") ~
-      get[Option[String]](s"$TABLE_NAME.$USER_INFO") ~
-      get[String](s"$TABLE_NAME.$INPUT_ID") ~
-      get[Option[String]](s"$TABLE_NAME.$JSON_PAYLOAD") map {
+    get[InputEventId](s"$ID") ~
+      get[String](s"$EVENT_SOURCE") ~
+      get[Int](s"$EVENT_TYPE") ~
+      get[LocalDateTime](s"$EVENT_TIME") ~
+      get[Option[String]](s"$USER_INFO") ~
+      get[String](s"$INPUT_ID") ~
+      get[Option[String]](s"$JSON_PAYLOAD") map {
         case id ~ eventSource ~ eventTypeRaw ~ eventTime ~ userInfo ~ inputId ~ jsonPayload =>
           InputEvent(id, eventSource, eventTypeRaw, eventTime, userInfo, inputId, jsonPayload)
     }
@@ -216,7 +216,7 @@ object InputEvent extends Logging {
         }
     }
 
-    val eventPresentIds = SQL"select #${models.input.SearchInput.TABLE_NAME}.#${models.input.SearchInput.ID} from #${models.input.SearchInput.TABLE_NAME} join #$TABLE_NAME ON #${models.input.SearchInput.TABLE_NAME}.#${models.input.SearchInput.ID} = #$TABLE_NAME.#$INPUT_ID"
+    val eventPresentIds = SQL"select #${models.input.SearchInput.TABLE_NAME}.#${models.input.SearchInput.ID} from #${models.input.SearchInput.TABLE_NAME} join #$TABLE_NAME ON #${models.input.SearchInput.TABLE_NAME}.#${models.input.SearchInput.ID} = ##$INPUT_ID"
       .as(sqlIdParser.*)
       .map(sId => SearchInputId(sId))
 
@@ -238,7 +238,7 @@ object InputEvent extends Logging {
         }
     }
 
-    val eventPresentIds = SQL"select #${models.spellings.CanonicalSpelling.TABLE_NAME}.#${models.spellings.CanonicalSpelling.ID} from #${models.spellings.CanonicalSpelling.TABLE_NAME} join #$TABLE_NAME on #${models.spellings.CanonicalSpelling.TABLE_NAME}.#${models.spellings.CanonicalSpelling.ID} = #$TABLE_NAME.#$INPUT_ID"
+    val eventPresentIds = SQL"select #${models.spellings.CanonicalSpelling.TABLE_NAME}.#${models.spellings.CanonicalSpelling.ID} from #${models.spellings.CanonicalSpelling.TABLE_NAME} join #$TABLE_NAME on #${models.spellings.CanonicalSpelling.TABLE_NAME}.#${models.spellings.CanonicalSpelling.ID} = ##$INPUT_ID"
       .as(sqlIdParser.*)
       .map(sId => CanonicalSpellingId(sId))
 

--- a/app/models/input/InputTag.scala
+++ b/app/models/input/InputTag.scala
@@ -68,13 +68,13 @@ object InputTag {
     InputTag(InputTagId(), solrIndexId, property, value, exported, predefined, LocalDateTime.now())
   }
 
-  val sqlParser: RowParser[InputTag] = get[InputTagId](s"$TABLE_NAME.$ID") ~
-    get[Option[SolrIndexId]](s"$TABLE_NAME.$SOLR_INDEX_ID") ~
-    get[Option[String]](s"$TABLE_NAME.$PROPERTY") ~
-    get[String](s"$TABLE_NAME.$VALUE") ~
-    get[Int](s"$TABLE_NAME.$EXPORTED") ~
-    get[Int](s"$TABLE_NAME.$PREDEFINED") ~
-    get[LocalDateTime](s"$TABLE_NAME.$LAST_UPDATE") map { case id ~ solrIndexId ~ property ~ value ~ exported ~ predefined ~ lastUpdate =>
+  val sqlParser: RowParser[InputTag] = get[InputTagId](s"$ID") ~
+    get[Option[SolrIndexId]](s"$SOLR_INDEX_ID") ~
+    get[Option[String]](s"$PROPERTY") ~
+    get[String](s"$VALUE") ~
+    get[Int](s"$EXPORTED") ~
+    get[Int](s"$PREDEFINED") ~
+    get[LocalDateTime](s"$LAST_UPDATE") map { case id ~ solrIndexId ~ property ~ value ~ exported ~ predefined ~ lastUpdate =>
       InputTag(id, solrIndexId, property,
         value, exported > 0, predefined > 0, lastUpdate)
   }

--- a/app/models/input/SearchInput.scala
+++ b/app/models/input/SearchInput.scala
@@ -48,12 +48,12 @@ object SearchInput {
   val COMMENT = "comment"
 
   val sqlParser: RowParser[SearchInput] = {
-    get[SearchInputId](s"$TABLE_NAME.$ID") ~
-      get[String](s"$TABLE_NAME.$TERM") ~
-      get[SolrIndexId](s"$TABLE_NAME.$SOLR_INDEX_ID") ~
-      get[LocalDateTime](s"$TABLE_NAME.$LAST_UPDATE") ~
-      get[Int](s"$TABLE_NAME.$STATUS") ~
-      get[String](s"$TABLE_NAME.$COMMENT") map { case id ~ term ~ indexId ~ lastUpdate ~ status ~ comment =>
+    get[SearchInputId](s"$ID") ~
+      get[String](s"$TERM") ~
+      get[SolrIndexId](s"$SOLR_INDEX_ID") ~
+      get[LocalDateTime](s"$LAST_UPDATE") ~
+      get[Int](s"$STATUS") ~
+      get[String](s"$COMMENT") map { case id ~ term ~ indexId ~ lastUpdate ~ status ~ comment =>
         SearchInput(id, indexId, term, lastUpdate, Status.isActiveFromStatus(status), comment)
     }
   }

--- a/app/models/input/TagInputAssociation.scala
+++ b/app/models/input/TagInputAssociation.scala
@@ -56,7 +56,7 @@ object TagInputAssociation {
     ids.grouped(100).toSeq.flatMap { idGroup =>
       SQL(s"select * from $TABLE_NAME a, ${InputTag.TABLE_NAME} t where a.$INPUT_ID in ({inputIds}) " +
         s"and a.$TAG_ID = t.${InputTag.ID} order by t.${InputTag.PROPERTY} asc, t.${InputTag.VALUE} asc").
-        on("inputIds" -> idGroup).as((InputTag.sqlParser ~ get[SearchInputId](s"$TABLE_NAME.$INPUT_ID")).*).
+        on("inputIds" -> idGroup).as((InputTag.sqlParser ~ get[SearchInputId](s"$INPUT_ID")).*).
         map { case tag ~ inputId =>
           inputId -> tag
         }

--- a/app/models/rules/DeleteRule.scala
+++ b/app/models/rules/DeleteRule.scala
@@ -22,9 +22,9 @@ object DeleteRule extends RuleObjectWithTerm[DeleteRule] {
   implicit val jsonFormat: OFormat[DeleteRule] = Json.format[DeleteRule]
 
   override val sqlParser: RowParser[DeleteRule] = {
-    get[DeleteRuleId](s"$TABLE_NAME.$ID") ~
-      get[String](s"$TABLE_NAME.$TERM") ~
-      get[Int](s"$TABLE_NAME.$STATUS") map { case id ~ term ~ status =>
+    get[DeleteRuleId](s"$ID") ~
+      get[String](s"$TERM") ~
+      get[Int](s"$STATUS") map { case id ~ term ~ status =>
       DeleteRule(id, term, Status.isActiveFromStatus(status))
     }
   }

--- a/app/models/rules/FilterRule.scala
+++ b/app/models/rules/FilterRule.scala
@@ -22,9 +22,9 @@ object FilterRule extends RuleObjectWithTerm[FilterRule] {
   implicit val jsonFormat: OFormat[FilterRule] = Json.format[FilterRule]
 
   override val sqlParser: RowParser[FilterRule] = {
-    get[FilterRuleId](s"$TABLE_NAME.$ID") ~
-      get[String](s"$TABLE_NAME.$TERM") ~
-      get[Int](s"$TABLE_NAME.$STATUS") map { case id ~ term ~ status =>
+    get[FilterRuleId](s"$ID") ~
+      get[String](s"$TERM") ~
+      get[Int](s"$STATUS") map { case id ~ term ~ status =>
       FilterRule(id, term, Status.isActiveFromStatus(status))
     }
   }

--- a/app/models/rules/RedirectRule.scala
+++ b/app/models/rules/RedirectRule.scala
@@ -33,9 +33,9 @@ object RedirectRule extends RuleObject[RedirectRule] {
   override def orderByField: String = TARGET
 
   override val sqlParser: RowParser[RedirectRule] = {
-    get[RedirectRuleId](s"$TABLE_NAME.$ID") ~
-      get[String](s"$TABLE_NAME.$TARGET") ~
-      get[Int](s"$TABLE_NAME.$STATUS") map { case id ~ target ~ status =>
+    get[RedirectRuleId](s"$ID") ~
+      get[String](s"$TARGET") ~
+      get[Int](s"$STATUS") map { case id ~ target ~ status =>
       RedirectRule(id, target, Status.isActiveFromStatus(status))
     }
   }

--- a/app/models/rules/SynonymRule.scala
+++ b/app/models/rules/SynonymRule.scala
@@ -36,10 +36,10 @@ object SynonymRule extends RuleObjectWithTerm[SynonymRule] {
   override def fieldNames: Seq[String] = super.fieldNames :+ TYPE
 
   val sqlParser: RowParser[SynonymRule] = {
-    get[SynonymRuleId](s"$TABLE_NAME.$ID") ~
-      get[Int](s"$TABLE_NAME.$TYPE") ~
-      get[String](s"$TABLE_NAME.$TERM") ~
-      get[Int](s"$TABLE_NAME.$STATUS") map { case id ~ synonymType ~ term ~ status =>
+    get[SynonymRuleId](s"$ID") ~
+      get[Int](s"$TYPE") ~
+      get[String](s"$TERM") ~
+      get[Int](s"$STATUS") map { case id ~ synonymType ~ term ~ status =>
         SynonymRule(id, synonymType, term, Status.isActiveFromStatus(status))
     }
   }

--- a/app/models/rules/UpDownRule.scala
+++ b/app/models/rules/UpDownRule.scala
@@ -39,11 +39,11 @@ object UpDownRule extends RuleObjectWithTerm[UpDownRule] {
   implicit val jsonFormat: OFormat[UpDownRule] = Json.format[UpDownRule]
 
   val sqlParser: RowParser[UpDownRule] = {
-    get[UpDownRuleId](s"$TABLE_NAME.$ID") ~
-      get[Int](s"$TABLE_NAME.$UP_DOWN_TYPE") ~
-      get[Int](s"$TABLE_NAME.$BOOST_MALUS_VALUE") ~
-      get[String](s"$TABLE_NAME.$TERM") ~
-      get[Int](s"$TABLE_NAME.$STATUS") map { case id ~ upDownType ~ boostMalusValue ~ term ~ status =>
+    get[UpDownRuleId](s"$ID") ~
+      get[Int](s"$UP_DOWN_TYPE") ~
+      get[Int](s"$BOOST_MALUS_VALUE") ~
+      get[String](s"$TERM") ~
+      get[Int](s"$STATUS") map { case id ~ upDownType ~ boostMalusValue ~ term ~ status =>
       UpDownRule(id, upDownType, boostMalusValue, term, Status.isActiveFromStatus(status))
     }
   }

--- a/app/models/spellings/AlternativeSpelling.scala
+++ b/app/models/spellings/AlternativeSpelling.scala
@@ -42,10 +42,10 @@ object AlternativeSpelling {
   implicit val jsonFormat: OFormat[AlternativeSpelling] = Json.format[AlternativeSpelling]
 
   val sqlParser: RowParser[AlternativeSpelling] = {
-      get[AlternativeSpellingId](s"$TABLE_NAME.$ID") ~
-      get[CanonicalSpellingId](s"$TABLE_NAME.$CANONICAL_SPELLING_ID") ~
-      get[String](s"$TABLE_NAME.$TERM") ~
-      get[Int](s"$TABLE_NAME.$STATUS") map { case id ~ canonicalSpellingId ~ term ~ status =>
+      get[AlternativeSpellingId](s"$ID") ~
+      get[CanonicalSpellingId](s"$CANONICAL_SPELLING_ID") ~
+      get[String](s"$TERM") ~
+      get[Int](s"$STATUS") map { case id ~ canonicalSpellingId ~ term ~ status =>
       AlternativeSpelling(id, canonicalSpellingId, term, Status.isActiveFromStatus(status))
     }
   }

--- a/app/models/spellings/CanonicalSpelling.scala
+++ b/app/models/spellings/CanonicalSpelling.scala
@@ -46,12 +46,12 @@ object CanonicalSpelling {
   implicit val jsonFormat: OFormat[CanonicalSpelling] = Json.format[CanonicalSpelling]
 
   val sqlParser: RowParser[CanonicalSpelling] = {
-      get[CanonicalSpellingId](s"$TABLE_NAME.$ID") ~
-      get[SolrIndexId](s"$TABLE_NAME.$SOLR_INDEX_ID") ~
-      get[String](s"$TABLE_NAME.$TERM") ~
-      get[Int](s"$TABLE_NAME.$STATUS") ~
-      get[String](s"$TABLE_NAME.$COMMENT") ~
-      get[LocalDateTime](s"$TABLE_NAME.$LAST_UPDATE") map { case id ~ indexId ~ term ~ status ~ comment ~ lastUpdate =>
+      get[CanonicalSpellingId](s"$ID") ~
+      get[SolrIndexId](s"$SOLR_INDEX_ID") ~
+      get[String](s"$TERM") ~
+      get[Int](s"$STATUS") ~
+      get[String](s"$COMMENT") ~
+      get[LocalDateTime](s"$LAST_UPDATE") map { case id ~ indexId ~ term ~ status ~ comment ~ lastUpdate =>
       CanonicalSpelling(id, indexId, term, Status.isActiveFromStatus(status), comment, lastUpdate)
     }
   }

--- a/app/services/SmuiMigrationLock.scala
+++ b/app/services/SmuiMigrationLock.scala
@@ -30,9 +30,9 @@ object SmuiMigrationLock extends Logging {
   val COMPLETED = "completed"
 
   val sqlParser: RowParser[SmuiMigrationLock] = {
-    get[String](s"$TABLE_NAME.$MIGRATION_KEY") ~
-      get[LocalDateTime](s"$TABLE_NAME.$LOCK_TIME") ~
-      get[Option[Int]](s"$TABLE_NAME.$COMPLETED") map { case migrationKey ~ lockTime ~ completedRawOpt =>
+    get[String](s"$MIGRATION_KEY") ~
+      get[LocalDateTime](s"$LOCK_TIME") ~
+      get[Option[Int]](s"$COMPLETED") map { case migrationKey ~ lockTime ~ completedRawOpt =>
       SmuiMigrationLock(
         migrationKey,
         lockTime,


### PR DESCRIPTION
This PR is based on experimenting with SMUI with sqlserver and mysql databases.   SQLServer specifically didn't like the table name being part of the column names.   With this PR (and some tweaks to the schema) SMUI could run against SQLServer.

I thought more about it, and thought that not having the table name in the rowparser would make it easier to read.   

I don't know if there are any other simplifications that could be made?