### PR TITLE
Replace bintray with new repo URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:11-buster as builder
 
 ARG NODE_VERSION=10
 
-RUN echo "deb https://dl.bintray.com/sbt/debian /" > /etc/apt/sources.list.d/sbt.list \
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" > /etc/apt/sources.list.d/sbt.list \
     && curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add \
     && apt-get update \
     && apt-get install -y sbt


### PR DESCRIPTION
I noticed the Docker build was failing due to bintray being deprecated.  The new URL appears to make things happy.