### PR TITLE
Add export filter by inputtag

### DIFF
--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -241,7 +241,7 @@ class ApiController @Inject()(authActionFactory: AuthActionFactory,
     logger.debug("In ApiController :: updateRulesTxtForSolrIndexAndTargetPlatform")
 
     // generate rules.txt(s)
-    val rulesFilesList = rulesTxtDeploymentService.generateRulesTxtContentWithFilenames(SolrIndexId(solrIndexId), targetSystem)
+    val rulesFilesList = rulesTxtDeploymentService.generateRulesTxtContentWithFilenamesList(SolrIndexId(solrIndexId), targetSystem)
 
     var apiResult: ApiResult = null
     for (rulesFiles <- rulesFilesList) {

--- a/app/models/SearchManagementRepository.scala
+++ b/app/models/SearchManagementRepository.scala
@@ -52,6 +52,10 @@ class SearchManagementRepository @Inject()(dbapi: DBApi, toggleService: FeatureT
     InputTag.loadAll()
   }
 
+  def listInputTagValuesForSolrIndexAndInputTagProperty(solrIndexId: SolrIndexId, inputTagProperty: String): List[InputTag] = db.withConnection { implicit connection =>
+    InputTag.loadAll().filter(_.solrIndexId== Option(solrIndexId)).filter(_.property == Option(inputTagProperty)).toList
+  }
+
   def addNewInputTag(inputTag: InputTag) = db.withConnection { implicit connection =>
     InputTag.insert(inputTag)
   }

--- a/app/models/querqy/QuerqyRulesTxtGenerator.scala
+++ b/app/models/querqy/QuerqyRulesTxtGenerator.scala
@@ -130,17 +130,18 @@ class QuerqyRulesTxtGenerator @Inject()(searchManagementRepository: SearchManage
     retQuerqyRulesTxt.toString()
   }
 
-  def hasValidInputTagValue(i: SearchInputWithRules, filterTagName: String, inputTag: InputTag): Boolean = {
-    // no filter on tags defined
-    if (filterTagName == null || filterTagName.isEmpty) {
+  def hasValidInputTagValue(searchInputWithRules: SearchInputWithRules, filterInputTagProperty: String, currentInputTag: InputTag): Boolean = {
+    // no filtering on tags
+    if (filterInputTagProperty.isEmpty) {
       return true
     }
-    val ruleTags = i.tags.filter(_.property.get.equals(filterTagName))
-    // common rules (without the input tag
-    if (inputTag == null) {
-      ruleTags.isEmpty
+    val filteredInputTagsOfCurrentRule = searchInputWithRules.tags.filter(_.property.get.equals(filterInputTagProperty))
+    if (currentInputTag == null) {
+      // common set of rules (inputTag == null): check whether the filterInputTagProperty as property is absent
+      filteredInputTagsOfCurrentRule.isEmpty
     } else {
-      ruleTags.map(t => t.id).contains(inputTag.id)
+      // other rules sets per input tag value: check whether the current tag has been set on the rule
+      filteredInputTagsOfCurrentRule.map(t => t.id).contains(currentInputTag.id)
     }
   }
 
@@ -153,7 +154,7 @@ class QuerqyRulesTxtGenerator @Inject()(searchManagementRepository: SearchManage
     * @return
     */
   // TODO resolve & test logic of render method (change interface to separate decompound from normal rules)
-  private def render(solrIndexId: SolrIndexId, separateRulesTxts: Boolean, renderCompoundsRulesTxt: Boolean, filterTagName: String, inputTag: InputTag): String = {
+  private def render(solrIndexId: SolrIndexId, separateRulesTxts: Boolean, renderCompoundsRulesTxt: Boolean, filterInputTagProperty: String, currentInputTag: InputTag): String = {
 
     val retQuerqyRulesTxt = new StringBuilder()
 
@@ -164,7 +165,7 @@ class QuerqyRulesTxtGenerator @Inject()(searchManagementRepository: SearchManage
       .filter(i => i.trimmedTerm.nonEmpty)
       // TODO it needs to be ensured, that a rule not only exists in the list, are active, BUT also has a filled term (after trim)
       .filter(_.hasAnyActiveRules)
-      .filter(i => hasValidInputTagValue(i, filterTagName, inputTag))
+      .filter(searchInputWithRules => hasValidInputTagValue(searchInputWithRules, filterInputTagProperty, currentInputTag))
 
     // TODO merge decompound identification login with ApiController :: validateSearchInputToErrMsg
 
@@ -184,12 +185,12 @@ class QuerqyRulesTxtGenerator @Inject()(searchManagementRepository: SearchManage
     renderListSearchInputRules(separateRules(listSearchInput))
   }
 
-  def renderSingleRulesTxt(solrIndexId: SolrIndexId, filterTagName: String, inputTag: InputTag): String = {
-    render(solrIndexId, false, false, filterTagName, inputTag)
+  def renderSingleRulesTxt(solrIndexId: SolrIndexId, filterInputTagProperty: String, currentInputTag: InputTag): String = {
+    render(solrIndexId, false, false, filterInputTagProperty, currentInputTag)
   }
 
-  def renderSeparatedRulesTxts(solrIndexId: SolrIndexId, renderCompoundsRulesTxt: Boolean, filterTagName: String, inputTag: InputTag): String = {
-    render(solrIndexId, true, renderCompoundsRulesTxt, filterTagName, inputTag)
+  def renderSeparatedRulesTxts(solrIndexId: SolrIndexId, renderCompoundsRulesTxt: Boolean, filterInputTagProperty: String, currentInputTag: InputTag): String = {
+    render(solrIndexId, true, renderCompoundsRulesTxt, filterInputTagProperty, currentInputTag)
   }
 
   /**

--- a/app/services/RulesTxtDeploymentService.scala
+++ b/app/services/RulesTxtDeploymentService.scala
@@ -36,7 +36,11 @@ class RulesTxtDeploymentService @Inject() (querqyRulesTxtGenerator: QuerqyRulesT
                                    sourceFileName: String,
                                    destinationFileName: String)
 
-  def generateRulesTxtContentWithFilenames(solrIndexId: SolrIndexId, targetSystem: String, logDebug: Boolean = true): List[RulesTxtsForSolrIndex] = {
+  def generateRulesTxtContentWithFilenames(solrIndexId: SolrIndexId, targetSystem: String, logDebug: Boolean = true): RulesTxtsForSolrIndex = {
+    generateRulesTxtContentWithFilenamesList(solrIndexId, targetSystem, logDebug).head
+  }
+
+  def generateRulesTxtContentWithFilenamesList(solrIndexId: SolrIndexId, targetSystem: String, logDebug: Boolean = true): List[RulesTxtsForSolrIndex] = {
     val filterTagName = appConfig.get[String]("smui2solr.deployment.tag.property")
     val inputTagValues: List[InputTag] =
       if (!filterTagName.isEmpty)
@@ -347,7 +351,7 @@ class RulesTxtDeploymentService @Inject() (querqyRulesTxtGenerator: QuerqyRulesT
     try {
       for (index <- searchManagementRepository.listAllSolrIndexes) {
         // TODO make targetSystem configurable from ApiController.downloadAllRulesTxtFiles ... go with "LIVE" from now (as there exist no different revisions of the search management content)!
-        val rulesList = generateRulesTxtContentWithFilenames(index.id, "LIVE", logDebug = false)
+        val rulesList = generateRulesTxtContentWithFilenamesList(index.id, "LIVE", logDebug = false)
         for (rules <- rulesList) {
           zipStream.putNextEntry(new ZipEntry(s"rules_${index.name}.txt"))
           zipStream.write(rules.regularRules.content.getBytes("UTF-8"))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -35,8 +35,8 @@ smui.deployment.git.repo-url=${?SMUI_DEPLOYMENT_GIT_REPO_URL}
 smui2solr.deployment.git.filename.common-rules-txt="rules.txt"
 smui2solr.deployment.git.filename.common-rules-txt=${?SMUI_DEPLOYMENT_GIT_FN_COMMON_RULES_TXT}
 
-smui2solr.deployment.tag.property=""
-smui2solr.deployment.tag.property=${?SMUI_2SOLR_DEPLOYMENT_BY_TAG}
+smui2solr.deployment.per.inputtag.property=""
+smui2solr.deployment.per.inputtag.property=${?SMUI_2SOLR_DEPLOYMENT_PER_INPUTTAG_PROPERTY}
 
 # Application Feature Toggles
 # ~~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -35,6 +35,9 @@ smui.deployment.git.repo-url=${?SMUI_DEPLOYMENT_GIT_REPO_URL}
 smui2solr.deployment.git.filename.common-rules-txt="rules.txt"
 smui2solr.deployment.git.filename.common-rules-txt=${?SMUI_DEPLOYMENT_GIT_FN_COMMON_RULES_TXT}
 
+smui2solr.deployment.tag.property=""
+smui2solr.deployment.tag.property=${?SMUI_2SOLR_DEPLOYMENT_BY_TAG}
+
 # Application Feature Toggles
 # ~~~~~
 toggle.activate-spelling=false

--- a/conf/push_common_rules.py
+++ b/conf/push_common_rules.py
@@ -1,0 +1,23 @@
+import sys,json,requests
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 3:
+        print('Usage: push_common_rules.py <rules.txt> <http://<solr_host:port>/solr/<collection>/querqy/rewriter/<rewriter_name>')
+        sys.exit(1)
+
+    rules_file = sys.argv[1]
+    rewriter_url = sys.argv[2]
+
+    f = open(rules_file, "r")
+
+    req = {
+        "class": "querqy.solr.rewriter.commonrules.CommonRulesRewriterFactory",
+        "config": {
+            "rules" : f.read()
+        }
+    }
+
+    resp = requests.post(rewriter_url + '?action=save', json=req)
+    if resp.status_code != 200:
+        sys.exit(2)

--- a/conf/push_replace.py
+++ b/conf/push_replace.py
@@ -1,0 +1,26 @@
+import sys,json,requests
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 3:
+        print('Usage: push_replace.py <rules.txt> <http://<solr_host:port>/solr/<collection>/querqy/rewriter/<rewriter_name>')
+        sys.exit(1)
+
+    rules_file = sys.argv[1]
+    rewriter_url = sys.argv[2]
+
+    f = open(rules_file, "r")
+
+    req = {
+        "class": "querqy.solr.rewriter.replace.ReplaceRewriterFactory",
+        "config": {
+            "rules": f.read(),
+            "ignoreCase": True,
+            "inputDelimiter": ";",
+            "querqyParser": "querqy.rewrite.commonrules.WhiteSpaceQuerqyParserFactory"
+        }
+    } 
+
+    resp = requests.post(rewriter_url + '?action=save', json=req)
+    if resp.status_code != 200:
+        sys.exit(2)

--- a/conf/smui2solrcloud.sh
+++ b/conf/smui2solrcloud.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SRC_TMP_FILE=$1
+DST_CP_FILE_TO=$2
+SOLR_HOST=$3
+SOLR_COLLECTION_NAME=$4
+DECOMPOUND_DST_CP_FILE_TO=$5
+TARGET_SYSTEM=$6
+REPLACE_RULES_SRC_TMP_FILE=$7
+REPLACE_RULES_DST_CP_FILE_TO=$8
+
+if grep -q -i -E '^https?://' <<<$SOLR_HOST; then
+  SOLR_BASE_URL=$SOLR_HOST
+else
+  SOLR_BASE_URL=http://$SOLR_HOST/solr
+fi
+
+echo "In smui2solrcloud.sh - script deploying rules to querqy api"
+echo "^-- SRC_TMP_FILE = $SRC_TMP_FILE"
+echo "^-- DST_CP_FILE_TO = $DST_CP_FILE_TO"
+echo "^-- SOLR_BASE_URL = $SOLR_BASE_URL"
+echo "^-- SOLR_COLLECTION_NAME: $SOLR_COLLECTION_NAME"
+echo "^-- DECOMPOUND_DST_CP_FILE_TO = $DECOMPOUND_DST_CP_FILE_TO"
+echo "^-- TARGET_SYSTEM = $TARGET_SYSTEM"
+echo "^-- REPLACE_RULES_SRC_TMP_FILE = $REPLACE_RULES_SRC_TMP_FILE"
+echo "^-- REPLACE_RULES_DST_CP_FILE_TO = $REPLACE_RULES_DST_CP_FILE_TO"
+
+
+# DEPLOYMENT
+#####
+
+echo "^-- Perform rules.txt deployment (decompound-rules.txt eventually)"
+
+echo "^-- ... rules.txt"
+python3 ./conf/push_common_rules.py $SRC_TMP_FILE "$SOLR_BASE_URL/$SOLR_COLLECTION_NAME/querqy/rewriter/$DST_CP_FILE_TO"
+if [ $? -ne 0 ]; then
+  exit 16
+fi
+
+echo "^-- ... replace-rules.txt"
+if ! [[ $REPLACE_RULES_SRC_TMP_FILE == "NONE" && $REPLACE_RULES_DST_CP_FILE_TO == "NONE" ]]
+then
+    python3 /smui/conf/push_replace.py $REPLACE_RULES_SRC_TMP_FILE "$SOLR_BASE_URL/$SOLR_COLLECTION_NAME/querqy/rewriter/$REPLACE_RULES_DST_CP_FILE_TO"
+fi
+
+# all ok
+echo "smui2solrcloud.sh - ok"
+exit 0

--- a/test/resources/TestRulesTxtImportTenantTags.json
+++ b/test/resources/TestRulesTxtImportTenantTags.json
@@ -1,0 +1,14 @@
+[
+  {
+    "property": "tenant",
+    "value": "AA"
+  },
+  {
+    "property": "tenant",
+    "value": "BB"
+  },
+  {
+    "property": "tenant",
+    "value": "CC"
+  }
+]


### PR DESCRIPTION
The goal of the change is to export smui rules by inputtag.

This change basically allows to export the SMUI rules in different querqy rewriter files based on an input tag value. This "flexible" assignment of smui rules to different querqy rewriters can be useful for e.g. A/B testing of SMUI rules.

The branch "add_export_filter_by_inputtag" in the o19s fork contains the code to export different files for a predefined (via env var) inputtag (e.g. inputtag “tenant”). When that configuration is set, the export behavior would change: instead of generating 1 rewriter txt file, it would create 1 rewriter txt file per “tenant” code (e.g. “common_rules_A” with rules with inputtag “tenant” = “A”, “common_rules_B” with rules with inputtag “tenant” = “B”, ...)

An additional change by dobestler is to allow to export based on the inputtag that is provided in the REST request rather than via env var. That would be a cleaner and more flexible solution. A new endpoint like GET /api/v1/allRulesTxtFilesByTag/{tag} instead of the environment var would be nice... but should probably be extended with tagname and tagvalue: GET /api/v1/allRulesTxtFilesByTag/{tagname}/{tagvalue} and cater for a way to export all tagvalues at once via GET /api/v1/allRulesTxtFilesByTag/{tagname} when tagvalue is absent.