### PR TITLE
Changing how sbt is installed since bintray is no longer available.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,14 @@
 FROM openjdk:11-buster as builder
 
 ARG NODE_VERSION=10
+ARG SBT_VERSION=1.5.6
 
-RUN echo "deb https://dl.bintray.com/sbt/debian /" > /etc/apt/sources.list.d/sbt.list \
-    && curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add \
-    && apt-get update \
-    && apt-get install -y sbt
+RUN \
+  curl -L -o sbt-$SBT_VERSION.deb https://repo.scala-sbt.org/scalasbt/debian/sbt-$SBT_VERSION.deb && \
+  dpkg -i sbt-$SBT_VERSION.deb && \
+  rm sbt-$SBT_VERSION.deb && \
+  apt-get update && \
+  apt-get -y install sbt
 
 RUN apt-get install -y lsb-release \
     && export DISTRO="$(lsb_release -s -c)" \


### PR DESCRIPTION
Pull request for #93 to address sbt not being available via bintray.