### PR TITLE
Version updates to enable build on M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM openjdk:11-buster as builder
 
 ARG NODE_VERSION=10
 
-# Fixed location for "SBT Debian packages no longer available" (see https://issueexplorer.com/issue/SpinalHDL/VexRiscv/188). Do not use "https://dl.bintray.com/sbt/debian" anymore.
-RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" > /etc/apt/sources.list.d/sbt.list \
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list \
     && curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add \
     && apt-get update \
     && apt-get install -y sbt
@@ -20,7 +19,7 @@ RUN apt-get install -y lsb-release \
 COPY . /smui
 WORKDIR /smui
 
-RUN --mount=target=/root/.ivy2,type=cache sbt "set test in assembly := {}" clean assembly
+RUN --mount=target=/root/.ivy2,type=cache sbt "set assembly / test := {}" clean assembly
 
 FROM openjdk:11-jre-slim-buster
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,13 +42,14 @@ libraryDependencies ++= {
     guice,
     jdbc,
     evolutions,
+    "com.jayway.jsonpath" % "json-path" % "2.7.0",
     "org.querqy" % "querqy-core" % "3.7.0", // querqy dependency
     "net.logstash.logback" % "logstash-logback-encoder" % "5.3", // JSON logging:
     "org.codehaus.janino" % "janino" % "3.0.8", // For using conditions in logback.xml:
     "mysql" % "mysql-connector-java" % "8.0.18", // TODO verify use of mysql-connector over explicit mariaDB connector instead
-    "org.postgresql" % "postgresql" % "42.2.5",
+    "org.postgresql" % "postgresql" % "42.5.1",
     "org.xerial" % "sqlite-jdbc" % "3.40.0.0",
-    "org.playframework.anorm" %% "anorm" % "2.6.4",
+    "org.playframework.anorm" %% "anorm" % "2.7.0",
     "com.typesafe.play" %% "play-json" % "2.6.12",
     "com.pauldijou" %% "jwt-play" % "4.1.0",
     "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.0" % Test,
@@ -63,10 +64,11 @@ libraryDependencies ++= {
 }
 
 dependencyOverrides ++= {
-  lazy val jacksonVersion = "2.9.10"
+  lazy val jacksonVersion = "2.14.1"
   Seq(
-    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-    "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
+    "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
+    "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
   )
 }
 
@@ -78,7 +80,7 @@ assembly / assemblyMergeStrategy := {
     // We don't need manifest files since sbt-assembly will create
     // one with the given settings
     MergeStrategy.discard
-  case "module-info.class" => MergeStrategy.discard
+  case x if x.endsWith("module-info.class") => MergeStrategy.discard
   case "play/reference-overrides.conf" => MergeStrategy.concat
   case x =>
     val oldStrategy = (assembly / assemblyMergeStrategy).value

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,9 @@ import com.typesafe.sbt.GitBranchPrompt
 name := "search-management-ui"
 version := "3.14.0"
 
-scalaVersion := "2.12.11"
+scalaVersion := "2.12.17"
+
+ThisBuild / evictionErrorLevel := Level.Info
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
@@ -19,7 +21,7 @@ lazy val root = (project in file("."))
   )
   .settings(dependencyCheckSettings: _*)
 
-updateOptions := updateOptions.value.withCachedResolution(cachedResoluton = true)
+updateOptions := updateOptions.value.withCachedResolution(cachedResolution = true)
 
 lazy val dependencyCheckSettings: Seq[Setting[_]] = {
   import DependencyCheckPlugin.autoImport._
@@ -68,10 +70,10 @@ dependencyOverrides ++= {
   )
 }
 
-mainClass in assembly := Some("play.core.server.ProdServerStart")
-fullClasspath in assembly += Attributed.blank(PlayKeys.playPackageAssets.value)
+assembly / mainClass := Some("play.core.server.ProdServerStart")
+assembly / fullClasspath += Attributed.blank(PlayKeys.playPackageAssets.value)
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case manifest if manifest.contains("MANIFEST.MF") =>
     // We don't need manifest files since sbt-assembly will create
     // one with the given settings
@@ -79,14 +81,14 @@ assemblyMergeStrategy in assembly := {
   case "module-info.class" => MergeStrategy.discard
   case "play/reference-overrides.conf" => MergeStrategy.concat
   case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
 }
 
 lazy val dockerNamespace = "querqy"
 lazy val dockerRepo = "smui"
 
-imageNames in docker := {
+docker / imageNames := {
   val semVerLevels = version.value.split('.')
   val majorVersion = semVerLevels.head
   val minorVersion = semVerLevels.drop(1).head
@@ -101,13 +103,13 @@ imageNames in docker := {
   }
 }
 
-dockerfile in docker := NativeDockerfile(baseDirectory.value / "Dockerfile")
+docker / dockerfile := NativeDockerfile(baseDirectory.value / "Dockerfile")
 
-dockerBuildArguments in docker := Map(
+docker / dockerBuildArguments := Map(
   "VERSION" -> version.value,
 )
 
-buildOptions in docker := BuildOptions(
+docker / buildOptions := BuildOptions(
   pullBaseImage = BuildOptions.Pull.Always
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.sbt.GitBranchPrompt
 
 name := "search-management-ui"
-version := "3.14.0"
+version := "3.15.0"
 
 scalaVersion := "2.12.17"
 

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ libraryDependencies ++= {
     "org.codehaus.janino" % "janino" % "3.0.8", // For using conditions in logback.xml:
     "mysql" % "mysql-connector-java" % "8.0.18", // TODO verify use of mysql-connector over explicit mariaDB connector instead
     "org.postgresql" % "postgresql" % "42.2.5",
-    "org.xerial" % "sqlite-jdbc" % "3.25.2",
+    "org.xerial" % "sqlite-jdbc" % "3.40.0.0",
     "org.playframework.anorm" %% "anorm" % "2.6.4",
     "com.typesafe.play" %% "play-json" % "2.6.12",
     "com.pauldijou" %% "jwt-play" % "4.1.0",
@@ -54,10 +54,9 @@ libraryDependencies ++= {
     "com.pauldijou" %% "jwt-play" % "4.1.0",
     "com.h2database" % "h2" % "1.4.197" % Test, // H2 DB for testing
     // Other databases as docker containers for testing with specific databases
-    "com.dimafeng" %% "testcontainers-scala" % "0.39.0" % Test,
-    "org.testcontainers" % "postgresql" % "1.15.2" % Test,
-    "org.testcontainers" % "mysql" % "1.15.2" % Test,
-    "org.xerial" % "sqlite-jdbc" % "3.28.0" % Test
+    "com.dimafeng" %% "testcontainers-scala" % "0.40.11" % Test,
+    "org.testcontainers" % "postgresql" % "1.17.6" % Test,
+    "org.testcontainers" % "mysql" % "1.17.6" % Test
   )
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.3
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,8 @@
-resolvers += "sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
-
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.2")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.8.0")
-
-addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "2.0.0")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.2")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.0.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.9.0")
+addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "4.2.0")
+addDependencyTreePlugin

--- a/ui-build.sbt
+++ b/ui-build.sbt
@@ -65,4 +65,4 @@ dist := (dist dependsOn `ui-prod-build`).value
 stage := (stage dependsOn `ui-prod-build`).value
 
 // Execute frontend test task prior to play test execution.
-test := ((test in Test) dependsOn `ui-test`).value
+test := ((Test / test) dependsOn `ui-test`).value


### PR DESCRIPTION
Current version did not build on M1 for me. Testcontainers complained about containers for wrong architecture, Docker build failed because Debian package for aarch64 could not be found. This updates libraries and while at it also the SBT version used to build. 