### PR TITLE
Use subject claim from jwt

### DIFF
--- a/app/controllers/auth/JWTJsonAuthenticatedAction.scala
+++ b/app/controllers/auth/JWTJsonAuthenticatedAction.scala
@@ -68,9 +68,10 @@ class JWTJsonAuthenticatedAction @Inject()(parser: BodyParsers.Default, appConfi
   }
 
   private def getUserRequestIfAvailable[A](token: JwtClaim, request: Request[A]): Request[A] = {
-    if (token.subject.isDefined) {
-      UserRequest(token.subject.get, request)
-    } else request
+    token.subject match {
+      case Some(subject) => UserRequest(subject, request)
+      case None => request
+    }
   }
 
   private def redirectToLoginPage(): Future[Result] = {

--- a/app/controllers/auth/JWTJsonAuthenticatedAction.scala
+++ b/app/controllers/auth/JWTJsonAuthenticatedAction.scala
@@ -1,5 +1,6 @@
 package controllers.auth
 
+import com.google.inject.Inject
 import com.jayway.jsonpath.JsonPath
 import net.minidev.json.JSONArray
 import pdi.jwt.{JwtAlgorithm, JwtClaim, JwtJson}
@@ -9,7 +10,7 @@ import play.api.{Configuration, Logging}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-class JWTJsonAuthenticatedAction(parser: BodyParsers.Default, appConfig: Configuration)(implicit ec: ExecutionContext)
+class JWTJsonAuthenticatedAction @Inject()(parser: BodyParsers.Default, appConfig: Configuration)(implicit ec: ExecutionContext)
   extends ActionBuilderImpl(parser) with Logging {
 
   logger.debug("In JWTJsonAuthenticatedAction")

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.sbt.GitBranchPrompt
 
 name := "search-management-ui"
-version := "3.16.0"
+version := "3.17.0"
 
 scalaVersion := "2.12.17"
 

--- a/test/auth/JWTJsonAuthenticatedActionSpec.scala
+++ b/test/auth/JWTJsonAuthenticatedActionSpec.scala
@@ -1,22 +1,22 @@
 package auth
 
-import java.security.{KeyPairGenerator, SecureRandom}
-import java.util.Base64
-
+import controllers.auth.{JWTJsonAuthenticatedAction, UserRequest}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
 import pdi.jwt.{JwtAlgorithm, JwtJson}
 import play.api.db.{Database, Databases}
-import play.api.{Application, Mode}
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.Json
-import play.api.mvc.{Cookie, Result}
+import play.api.libs.json.{JsString, Json}
+import play.api.mvc.{Cookie, Request, Result, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import play.api.{Application, Mode}
 
-import scala.concurrent.Future
+import java.security.{KeyPairGenerator, SecureRandom}
+import java.util.Base64
+import scala.concurrent.{ExecutionContext, Future}
 
 class JWTJsonAuthenticatedActionSpec extends PlaySpec with MockitoSugar with GuiceOneAppPerTest with ScalaFutures {
 
@@ -143,6 +143,40 @@ class JWTJsonAuthenticatedActionSpec extends PlaySpec with MockitoSugar with Gui
         result.header.status mustBe 200
       }
     }
+
+    "return a UserRequest if the subject claim is present" in {
+      val userName = "test_user"
+      val request = FakeRequest(GET, "/api/v1/allRulesTxtFiles")
+        .withCookies(buildJWTCookie(userName, Seq("search-manager")))
+      var authenticator = app.injector.instanceOf[JWTJsonAuthenticatedAction]
+      var modifiedRequest: Request[Any] = request;
+
+      var authenticated = authenticator.invokeBlock(request, (receivedRequest: Request[Any]) => {
+        modifiedRequest = receivedRequest
+        Future.apply(Results.Ok)(ExecutionContext.global)
+      })
+
+      whenReady(authenticated) { _ =>
+        modifiedRequest mustBe a[UserRequest[Any]]
+      }
+    }
+
+    "not touch the request if the subject claim is not present" in {
+      val request = FakeRequest(GET, "/api/v1/allRulesTxtFiles")
+        .withCookies(buildJWTCookie(null, Seq("search-manager")))
+      var authenticator = app.injector.instanceOf[JWTJsonAuthenticatedAction]
+      var modifiedRequest: Request[Any] = request;
+
+      var authenticated = authenticator.invokeBlock(request, (receivedRequest: Request[Any]) => {
+        modifiedRequest = receivedRequest
+        Future.apply(Results.Ok)(ExecutionContext.global)
+      })
+
+      whenReady(authenticated) { _ =>
+        modifiedRequest mustBe request
+        modifiedRequest must not be a[UserRequest[Any]]
+      }
+    }
   }
 
   private def generateRsaKeyPair() = {
@@ -151,8 +185,11 @@ class JWTJsonAuthenticatedActionSpec extends PlaySpec with MockitoSugar with Gui
     keyGen.generateKeyPair()
   }
 
-  private def buildJWTCookie(userName: String, roles: Seq[String], value: Option[String] = None): Cookie = {
-    val token = Json.obj(("roles", roles), ("user", userName))
+  private def buildJWTCookie(userName: String, roles: Seq[String] = Seq.empty, value: Option[String] = None): Cookie = {
+    var token = Json.obj(("roles", roles))
+    if (userName != null) {
+      token = token + ("sub", JsString(userName))
+    }
 
     Cookie(
       name = getJwtConfiguration("cookie.name"),


### PR DESCRIPTION
This PR extends the JWTJsonAuthenticatedAction class to use the subject claim (if present), to enhance the request with the user name, similar to what is done in the BasicAuthAuthenticatedAction class.

I added a couple tests to check that this functionality works even if there is no "sub" claim. Disclaimer: Is the first scala test I write, so maybe the idea is right but the implementation sucks.