### PR TITLE
Reflect "publishing is running" in modal and disable buttons

### DIFF
--- a/frontend/src/app/components/header-nav/header-nav.component.html
+++ b/frontend/src/app/components/header-nav/header-nav.component.html
@@ -175,17 +175,28 @@
       class="btn btn-success mr-2"
       type="button"
       (click)="requestPublishRulesTxtToSolr('LIVE')"
+      [attr.disabled]="
+        !currentSolrIndexId || deploymentRunningForStage == 'LIVE'
+        ? ''
+        : null
+        "
     >
       <i class="fa fa-thumbs-up smui-icon"></i>
-      Yes, publish to LIVE
+      {{ publishToLiveButtonText() }}
+
     </button>
     <button
       class="btn btn-danger"
       type="button"
       (click)="modalService.close('confirm-publish-live')"
+      [attr.disabled]="
+        !currentSolrIndexId || deploymentRunningForStage == 'LIVE'
+        ? ''
+        : null
+        "
     >
       <i class="fa fa-ban smui-icon"></i>
-      No, cancel publish
+      Cancel publish
     </button>
   </div>
 </app-smui-modal>

--- a/frontend/src/app/components/header-nav/header-nav.component.ts
+++ b/frontend/src/app/components/header-nav/header-nav.component.ts
@@ -88,14 +88,14 @@ export class HeaderNavComponent implements OnInit {
       this.solrService
         .updateRulesTxtForSolrIndex(this.currentSolrIndexId, targetPlatform)
         .then(apiResult => {
-          this.deploymentRunningForStage = undefined
           this.modalService.close('confirm-publish-live')
+          this.deploymentRunningForStage = undefined
           this.showSuccessMsg(apiResult.message)
           this.loadLatestDeploymentLogInfo()
         })
         .catch(error => {
-          this.deploymentRunningForStage = undefined
           this.modalService.close('confirm-publish-live')
+          this.deploymentRunningForStage = undefined
           this.showErrorMsg(error.error.message)
         });
     } // TODO handle else-case, if no currentSolrIndexId selected


### PR DESCRIPTION
Why: Long running publishing can lead the waiting user to click again on the publish or cancel button.
How: Reflect that publishing is running and disable buttons

![Screenshot 2023-12-13 at 23 37 29](https://github.com/querqy/smui/assets/11744444/95342811-b11d-40a4-90c4-7a2ab9fbf71d)

![Screenshot 2023-12-13 at 23 37 40](https://github.com/querqy/smui/assets/11744444/60df3247-b37e-40a2-9960-3291b4777148)

