### PR TITLE
Fix prelive name config value

### DIFF
--- a/app/models/FeatureToggleModel.scala
+++ b/app/models/FeatureToggleModel.scala
@@ -55,7 +55,7 @@ package object FeatureToggleModel extends Logging {
     private val FEATURE_TOGGLE_RULE_DEPLOYMENT_CUSTOM_SCRIPT_SMUI2SOLR_SH_PATH = "toggle.rule-deployment.custom-script-SMUI2SOLR-SH_PATH"
     private val FEATURE_TOGGLE_HEADLINE = "toggle.headline"
     private val FEATURE_TOGGLE_DEPLOYMENT_LABEL = "toggle.rule-deployment-label"
-    private val FEATURE_TOGGLE_DEPLOYMENT_PRELIVE_LABEL = "toggle.rule-deployment-prelive-label"
+    private val FEATURE_TOGGLE_DEPLOYMENT_PRELIVE_LABEL = "toggle.deploy-prelive-fn-label"
     private val ACTIVATE_RULE_TAGGING = "toggle.rule-tagging"
     private val PREDEFINED_TAGS_FILE = "toggle.predefined-tags-file"
     private val SMUI_VERSION = "smui.version"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.sbt.GitBranchPrompt
 
 name := "search-management-ui"
-version := "4.0.9"
+version := "4.0.10"
 maintainer := "Contact productful.io <hello@productful.io>"
 
 scalaVersion := "2.12.17"

--- a/frontend/src/app/components/header-nav/header-nav.component.html
+++ b/frontend/src/app/components/header-nav/header-nav.component.html
@@ -82,8 +82,8 @@
       <ng-container *ngFor="let singleDeploymentInfo of deploymentLogInfo; index as idxDeploy">
         <span class="depl-info-row-instance">
           <b>{{ (singleDeploymentInfo.targetSystem == 'PRELIVE' ?
-                  featureToggleService.getSync('toggle.deploy-prelive-fn-label') :
-                  featureToggleService.getSync('toggle.rule-deployment-label'))}}</b> deployment:</span>
+                  featureToggleService.getSyncToggleDeploymentLabel('PRELIVE') :
+                  featureToggleService.getSyncToggleDeploymentLabel('LIVE'))}}</b> deployment:</span>
         <span class="depl-info-row-datetime"><b>{{ singleDeploymentInfo.formattedDateTime }}</b></span>
         <span class="depl-info-row-result">
           <b
@@ -164,9 +164,9 @@
   </div>
 </app-smui-modal>
 
-<app-smui-modal id="confirm-publish-live" title="Confirm publish to {{ featureToggleService.getSync('toggle.rule-deployment-label') }}">
+<app-smui-modal id="confirm-publish-live" title="Confirm publish to {{ featureToggleService.getSyncToggleDeploymentLabel('LIVE') }}">
   <div content>
-    <p>Are you sure to publish current Search Rules to {{ featureToggleService.getSync('toggle.rule-deployment-label') }}?</p>
+    <p>Are you sure to publish current Search Rules to {{ featureToggleService.getSyncToggleDeploymentLabel('LIVE') }}?</p>
   </div>
   <div footer class="btn-toolbar">
     <button
@@ -175,7 +175,7 @@
       (click)="requestPublishRulesTxtToSolr('LIVE')"
     >
       <i class="fa fa-thumbs-up smui-icon"></i>
-      Yes, publish to {{ featureToggleService.getSync('toggle.rule-deployment-label') }}
+      Yes, publish to {{ featureToggleService.getSyncToggleDeploymentLabel('LIVE') }}
     </button>
     <button
       class="btn btn-danger"

--- a/frontend/src/app/components/header-nav/header-nav.component.html
+++ b/frontend/src/app/components/header-nav/header-nav.component.html
@@ -82,7 +82,7 @@
       <ng-container *ngFor="let singleDeploymentInfo of deploymentLogInfo; index as idxDeploy">
         <span class="depl-info-row-instance">
           <b>{{ (singleDeploymentInfo.targetSystem == 'PRELIVE' ?
-                  featureToggleService.getSync('toggle.rule-deployment-prelive-label') :
+                  featureToggleService.getSync('toggle.deploy-prelive-fn-label') :
                   featureToggleService.getSync('toggle.rule-deployment-label'))}}</b> deployment:</span>
         <span class="depl-info-row-datetime"><b>{{ singleDeploymentInfo.formattedDateTime }}</b></span>
         <span class="depl-info-row-result">

--- a/frontend/src/app/components/header-nav/header-nav.component.ts
+++ b/frontend/src/app/components/header-nav/header-nav.component.ts
@@ -103,8 +103,8 @@ export class HeaderNavComponent implements OnInit {
 
   public publishToPreliveButtonText(): string {
     return this.deploymentRunningForStage === 'PRELIVE'
-      ? 'Publishing to ' + this.featureToggleService.getSync('toggle.rule-deployment-prelive-label') + '...'
-      : 'Publish to ' + this.featureToggleService.getSync('toggle.rule-deployment-prelive-label') + '';
+      ? 'Publishing to ' + this.featureToggleService.getSync('toggle.deploy-prelive-fn-label') + '...'
+      : 'Publish to ' + this.featureToggleService.getSync('toggle.deploy-prelive-fn-label') + '';
   }
 
   public publishToLiveButtonText(): string {

--- a/frontend/src/app/components/header-nav/header-nav.component.ts
+++ b/frontend/src/app/components/header-nav/header-nav.component.ts
@@ -103,14 +103,14 @@ export class HeaderNavComponent implements OnInit {
 
   public publishToPreliveButtonText(): string {
     return this.deploymentRunningForStage === 'PRELIVE'
-      ? 'Publishing to ' + this.featureToggleService.getSync('toggle.deploy-prelive-fn-label') + '...'
-      : 'Publish to ' + this.featureToggleService.getSync('toggle.deploy-prelive-fn-label') + '';
+      ? 'Publishing to ' + this.featureToggleService.getSyncToggleDeploymentLabel('PRELIVE') + '...'
+      : 'Publish to ' + this.featureToggleService.getSyncToggleDeploymentLabel('PRELIVE') + '';
   }
 
   public publishToLiveButtonText(): string {
     return this.deploymentRunningForStage === 'LIVE'
-      ? 'Publishing to ' + this.featureToggleService.getSync('toggle.rule-deployment-label') + '...'
-      : 'Publish to ' + this.featureToggleService.getSync('toggle.rule-deployment-label') + '';
+      ? 'Publishing to ' + this.featureToggleService.getSyncToggleDeploymentLabel('LIVE') + '...'
+      : 'Publish to ' + this.featureToggleService.getSyncToggleDeploymentLabel('LIVE') + '';
   }
 
   public publishSolrConfig() {

--- a/frontend/src/app/services/feature-toggle.service.ts
+++ b/frontend/src/app/services/feature-toggle.service.ts
@@ -10,7 +10,7 @@ const FEATURE_ACTIVATE_SPELLING = 'toggle.activate-spelling';
 const FEATURE_ACTIVATE_EVENTHISTORY = 'toggle.activate-eventhistory';
 const FEATURE_CUSTOM_UP_DOWN_MAPPINGS = 'toggle.ui-concept.custom.up-down-dropdown-mappings';
 const FEATURE_TOGGLE_DEPLOYMENT_LABEL = "toggle.rule-deployment-label";
-const FEATURE_TOGGLE_DEPLOYMENT_PRELIVE_LABEL = "toggle.rule-deployment-prelive-label";
+const FEATURE_TOGGLE_DEPLOYMENT_PRELIVE_LABEL = "toggle.deploy-prelive-fn-label";
 
 
 @Injectable({

--- a/frontend/src/app/services/feature-toggle.service.ts
+++ b/frontend/src/app/services/feature-toggle.service.ts
@@ -90,4 +90,12 @@ export class FeatureToggleService {
     }
   }
 
+  getSyncToggleDeploymentLabel(stage: string): any {
+    const s =
+      (stage == 'PRELIVE') ?
+        FEATURE_TOGGLE_DEPLOYMENT_PRELIVE_LABEL :
+        FEATURE_TOGGLE_DEPLOYMENT_LABEL;
+    return this.getSync(s);
+  }
+
 }


### PR DESCRIPTION
FeatureToggleModel used incorrect configuration label to retrieve the name of the "prelive" deployment