### PR TITLE
Fix 8.sql evolution

### DIFF
--- a/conf/evolutions/default/8.sql
+++ b/conf/evolutions/default/8.sql
@@ -10,5 +10,5 @@ create unique index suggested_solr_field_name_solr_index on suggested_solr_field
 
 # --- !Downs
 
-drop index solr_index_field_name
-drop index suggested_solr_field_name_solr_index;
+drop index solr_index_field_name on solr_index;
+drop index suggested_solr_field_name_solr_index on suggested_solr_field;


### PR DESCRIPTION
The Downs Instructions are wrong. I wonder how this ever worked. Maybe depending on the SQL Engine. At least MariaDB can not execute these DROP index statements without semicolon and without table name.