### PR TITLE
Batch synonyms from a csv file

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "angular2-multiselect-dropdown": "^4.6.6",
     "angular2-toaster": "^11.0.1",
     "bootstrap": "^4.5.0",
+    "papaparse": "^5.5.2",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -100,7 +100,7 @@ import {
     SuggestedFieldsComponent,
     SuggestedFieldsCreateComponent,
     SuggestedFieldsListComponent,
-    PreviewLinkComponent
+    PreviewLinkComponent,
   ],
   providers: [
     CommonsService,

--- a/frontend/src/app/components/details/rule-management/rule-management.component.ts
+++ b/frontend/src/app/components/details/rule-management/rule-management.component.ts
@@ -309,7 +309,7 @@ export class RuleManagementComponent implements OnChanges, OnInit, AfterContentC
     console.log('In SearchInputDetailComponent :: addNewUpDownRule');
 
     const emptyUpDownRule: UpDownRule = {
-      id: this.randomUUID(),
+      id: randomUUID(),
       term: '',
       isActive: true
     };
@@ -341,7 +341,7 @@ export class RuleManagementComponent implements OnChanges, OnInit, AfterContentC
     console.log('In SearchInputDetailComponent :: addNewFilterRule');
 
     const emptyFilterRule: FilterRule = {
-      id: this.randomUUID(),
+      id: randomUUID(),
       term: '',
       isActive: true
     };
@@ -370,7 +370,7 @@ export class RuleManagementComponent implements OnChanges, OnInit, AfterContentC
     console.log('In SearchInputDetailComponent :: addNewDeleteRule');
 
     const emptyDeleteRule: DeleteRule = {
-      id: this.randomUUID(),
+      id: randomUUID(),
       term: '',
       isActive: true
     };
@@ -394,7 +394,7 @@ export class RuleManagementComponent implements OnChanges, OnInit, AfterContentC
     console.log('In SearchInputDetailComponent :: addNewRedirectRule');
 
     const emptyRedirectRule: RedirectRule = {
-      id: this.randomUUID(),
+      id: randomUUID(),
       target: '',
       isActive: true
     };

--- a/frontend/src/app/components/details/rule-management/rule-management.component.ts
+++ b/frontend/src/app/components/details/rule-management/rule-management.component.ts
@@ -27,6 +27,7 @@ import {
   UpDownRule,
   PreviewSection
 } from '../../../models';
+import {randomUUID} from '../../../lib/uuid';
 import {
   CommonsService,
   FeatureToggleService,
@@ -284,7 +285,7 @@ export class RuleManagementComponent implements OnChanges, OnInit, AfterContentC
     console.log('In SearchInputDetailComponent :: addNewSynonym');
 
     const emptySynonymRule: SynonymRule = {
-      id: this.randomUUID(),
+      id: randomUUID(),
       synonymType: 0,
       term: '',
       isActive: true
@@ -558,17 +559,6 @@ export class RuleManagementComponent implements OnChanges, OnInit, AfterContentC
     }
 
     return idxMinimumDistance;
-  }
-
-  // taken from https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
-  private randomUUID() {
-    /* eslint-disable */
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      const r = (Math.random() * 16) | 0,
-        v = c == 'x' ? r : (r & 0x3) | 0x8
-      return v.toString(16)
-    })
-    /* eslint-enable */
   }
 
   private updateSelectedTagsInModel() {

--- a/frontend/src/app/components/rules-panel/rules-search/rules-search.component.css
+++ b/frontend/src/app/components/rules-panel/rules-search/rules-search.component.css
@@ -10,3 +10,7 @@
 .create-button {
   margin-left: 0.5rem;
 }
+
+.full-width {
+  width: 100%;
+}

--- a/frontend/src/app/components/rules-panel/rules-search/rules-search.component.html
+++ b/frontend/src/app/components/rules-panel/rules-search/rules-search.component.html
@@ -89,7 +89,7 @@
   title="Import rules from CSV"
 >
   <div content>
-    <div class="progress" *ngIf="progress">
+    <div class="progress" [style.visibility]="progress ? 'visible' : 'hidden'">
       <div class="progress-bar"
         [style.width.%]="progress"
         [attr.aria-valuenow]="progress"

--- a/frontend/src/app/components/rules-panel/rules-search/rules-search.component.html
+++ b/frontend/src/app/components/rules-panel/rules-search/rules-search.component.html
@@ -45,6 +45,13 @@
       >
         <i class="fa fa-plus" aria-hidden="true"></i> New
       </button>
+      <button
+        class="btn btn-success create-button"
+        type="button"
+        (click)="openFileModal()"
+      >
+        <i class="fa fa-upload" aria-hidden="true"></i> Import
+      </button>
     </span>
   </div>
 </app-smui-card>
@@ -75,5 +82,42 @@
     >
       <i class="fa fa-list smui-icon"></i>Rule Management
     </button>
+  </div>
+</app-smui-modal>
+<app-smui-modal
+  id="file-import"
+  title="Import rules from CSV"
+>
+  <div content>
+    <p>
+      Your csv must be in the following format (do not include the header row)
+    </p>
+    <table class="table">
+      <thead class="thead-dark">
+        <tr>
+          <th>search term</th>
+          <th>synonym</th>
+          <th>comment</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>boot</td>
+          <td>shoe</td>
+          <td>Requested by footware</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div footer class="btn-toolbar">
+    <div class="custom-file">
+      <input
+        type="file"
+        class="custom-file-input"
+        id="customFile"
+        (change)="fileSelect($event)"
+      >
+      <label class="custom-file-label" for="customFile">Choose file</label>
+    </div>
   </div>
 </app-smui-modal>

--- a/frontend/src/app/components/rules-panel/rules-search/rules-search.component.html
+++ b/frontend/src/app/components/rules-panel/rules-search/rules-search.component.html
@@ -109,10 +109,11 @@
       </tbody>
     </table>
   </div>
-  <div footer class="btn-toolbar">
+  <div footer class="btn-toolbar full-width">
     <div class="custom-file">
       <input
         type="file"
+        accept="text/csv"
         class="custom-file-input"
         id="customFile"
         (change)="fileSelect($event)"

--- a/frontend/src/app/components/rules-panel/rules-search/rules-search.component.html
+++ b/frontend/src/app/components/rules-panel/rules-search/rules-search.component.html
@@ -89,6 +89,15 @@
   title="Import rules from CSV"
 >
   <div content>
+    <div class="progress" *ngIf="progress">
+      <div class="progress-bar"
+        [style.width.%]="progress"
+        [attr.aria-valuenow]="progress"
+        role="progressbar"
+        aria-valuemin="0"
+        aria-valuemax="100"
+      ></div>
+    </div>
     <p>
       Your csv must be in the following format (do not include the header row)
     </p>

--- a/frontend/src/app/components/rules-panel/rules-search/rules-search.component.ts
+++ b/frontend/src/app/components/rules-panel/rules-search/rules-search.component.ts
@@ -93,7 +93,9 @@ export class RulesSearchComponent implements OnChanges {
           .then(
             () => {
               this.modalService.close(fileImportModal)
-              this.refreshAndSelectListItemById.emit(searchInputs[0].id);
+              if (searchInputs.length > 0) {
+                this.refreshAndSelectListItemById.emit(searchInputs[0].id);
+              }
             }
           )
           .error(err => this.showErrorMsg.emit(err.message));

--- a/frontend/src/app/components/rules-panel/rules-search/rules-search.component.ts
+++ b/frontend/src/app/components/rules-panel/rules-search/rules-search.component.ts
@@ -83,7 +83,7 @@ export class RulesSearchComponent implements OnChanges {
       const ruleCreations = this.csvImportService.import(
         file,
         this.currentSolrIndexId,
-        (percentage) => {
+        (percentage: number) => {
           this.progress = percentage;
           this.cdr.detectChanges();
         }

--- a/frontend/src/app/components/rules-panel/rules-search/rules-search.component.ts
+++ b/frontend/src/app/components/rules-panel/rules-search/rules-search.component.ts
@@ -17,6 +17,7 @@ import {
 import Papa from 'papaparse';
 import {InputTag, ListItem} from '../../../models';
 import {rowsToSearchInputs} from '../../../lib/csv';
+const fileImportModal = 'file-import';
 
 @Component({
   selector: 'app-smui-rules-search',
@@ -68,7 +69,7 @@ export class RulesSearchComponent implements OnChanges {
   }
 
   openFileModal(): void {
-    this.modalService.open('file-import');
+    this.modalService.open(fileImportModal);
   }
 
   fileSelect(event: Event): void {
@@ -91,7 +92,7 @@ export class RulesSearchComponent implements OnChanges {
         ruleCreations
           .then(
             () => {
-              this.modalService.close('file-import')
+              this.modalService.close(fileImportModal)
               this.refreshAndSelectListItemById.emit(searchInputs[0].id);
             }
           )

--- a/frontend/src/app/components/rules-panel/rules-search/rules-search.component.ts
+++ b/frontend/src/app/components/rules-panel/rules-search/rules-search.component.ts
@@ -88,12 +88,17 @@ export class RulesSearchComponent implements OnChanges {
                   });
               });
           }, Promise.resolve());
-        ruleCreations.then(
-          () => {
-            this.modalService.close('file-import')
-            this.refreshAndSelectListItemById.emit(searchInputs[0].id);
-          }
-        );
+        ruleCreations
+          .then(
+            () => {
+              this.modalService.close('file-import')
+              this.refreshAndSelectListItemById.emit(searchInputs[0].id);
+            }
+          )
+          .error(err => this.showErrorMsg.emit(err.message));
+      },
+      error: (err, file, inputElem, reason) => {
+        this.showErrorMsg.emit(err);
       }
     });
   }

--- a/frontend/src/app/lib/csv.spec.ts
+++ b/frontend/src/app/lib/csv.spec.ts
@@ -1,0 +1,50 @@
+import {rowsToSearchInputs} from './csv';
+
+describe('rowsToSearchInputs', () => {
+  it('parses no inputs when there are no rows', () => {
+    expect(rowsToSearchInputs([])).toHaveSize(0);
+  });
+
+  it('ignores rows with less than 3 columns', () => {
+    expect(rowsToSearchInputs([['abc', '123']])).toHaveSize(0);
+  });
+
+  it('ignores rows with more than 3 columns', () => {
+    expect(rowsToSearchInputs([['abc', '123', 'def', '456']])).toHaveSize(0);
+  });
+
+  it('parses rows with 3 columns', () => {
+    const inputs = rowsToSearchInputs([
+      ['term', 'synonym', 'comment']
+    ]);
+    expect(inputs).toHaveSize(1);
+    expect(inputs[0].id).toBeInstanceOf(String);
+    expect(inputs[0].term).toEqual('term');
+    expect(inputs[0].redirectRules).toEqual([]);
+    expect(inputs[0].filterRules).toEqual([]);
+    expect(inputs[0].tags).toEqual([]);
+    expect(inputs[0].upDownRules).toEqual([]);
+    expect(inputs[0].synonymRules).toHaveSize(1);
+    expect(inputs[0].synonymRules[0].term).toEqual('synonym');
+    expect(inputs[0].synonymRules[0].isActive).toEqual(true);
+    expect(inputs[0].synonymRules[0].synonymType).toEqual(0);
+    expect(inputs[0].synonymRules[0].id).toBeInstanceOf(String);
+  });
+
+  it('groups rows with the same search term', () => {
+    const inputs = rowsToSearchInputs([
+      ['term', 'synonym', 'comment'],
+      ['term', 'another synonym', 'comment'],
+    ]);
+    expect(inputs).toHaveSize(1);
+    expect(inputs[0].synonymRules).toHaveSize(2);
+  });
+
+  it('creates one SearchInput per term', () => {
+    const inputs = rowsToSearchInputs([
+      ['term', 'synonym', 'comment'],
+      ['term2', 'another synonym', 'comment'],
+    ]);
+    expect(inputs).toHaveSize(2);
+  });
+});

--- a/frontend/src/app/lib/csv.ts
+++ b/frontend/src/app/lib/csv.ts
@@ -1,0 +1,37 @@
+import {randomUUID} from './uuid';
+
+function makeActiveSynonymTerm(synonymTerm) {
+  return {
+    term: synonymTerm,
+    isActive: true,
+    synonymType: 0,
+    id: randomUUID()
+  };
+}
+
+export function rowsToSearchInputs(rows: string[][]): SearchInput[] {
+  return rows
+    .filter(row => row.length === 3)
+    .reduce((searchInputs, row) => {
+      console.log(row);
+      const [term, synonymTerm, comment] = row;
+      const searchInput = searchInputs.find(searchInput => searchInput.term === term);
+      if (!searchInput) {
+        searchInputs = searchInputs.concat({
+          id: randomUUID(),
+          term,
+          synonymRules: [makeActiveSynonymTerm(synonymTerm)],
+          isActive: true,
+          redirectRules: [],
+          deleteRules: [],
+          filterRules: [],
+          tags: [],
+          upDownRules: [],
+          comment,
+        })
+      } else {
+        searchInput.synonymRules.push(makeActiveSynonymTerm(synonymTerm))
+      }
+      return searchInputs;
+     }, []);
+}

--- a/frontend/src/app/lib/csv.ts
+++ b/frontend/src/app/lib/csv.ts
@@ -1,6 +1,7 @@
+import {SynonymRule, SearchInput} from '../models';
 import {randomUUID} from './uuid';
 
-function makeActiveSynonymTerm(synonymTerm) {
+function makeActiveSynonymTerm(synonymTerm: string): SynonymRule {
   return {
     term: synonymTerm,
     isActive: true,
@@ -33,5 +34,5 @@ export function rowsToSearchInputs(rows: string[][]): SearchInput[] {
         searchInput.synonymRules.push(makeActiveSynonymTerm(synonymTerm))
       }
       return searchInputs;
-     }, []);
+     }, [] as SearchInput[]);
 }

--- a/frontend/src/app/lib/csv.ts
+++ b/frontend/src/app/lib/csv.ts
@@ -14,7 +14,6 @@ export function rowsToSearchInputs(rows: string[][]): SearchInput[] {
   return rows
     .filter(row => row.length === 3)
     .reduce((searchInputs, row) => {
-      console.log(row);
       const [term, synonymTerm, comment] = row;
       const searchInput = searchInputs.find(searchInput => searchInput.term === term);
       if (!searchInput) {

--- a/frontend/src/app/lib/uuid.ts
+++ b/frontend/src/app/lib/uuid.ts
@@ -1,0 +1,10 @@
+
+// taken from https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
+export function randomUUID(): string {
+  /* eslint-disable */
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    const r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+  /* eslint-enable */
+}

--- a/frontend/src/app/services/commons.service.ts
+++ b/frontend/src/app/services/commons.service.ts
@@ -1,15 +1,11 @@
 import { Injectable, SimpleChanges } from '@angular/core';
+import {randomUUID} from '../lib/uuid';
 
 @Injectable()
 export class CommonsService {
 
   generateUUID(): string {
-    /* eslint-disable */
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      const r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
-      return v.toString(16);
-    });
-    /* eslint-enable */
+    return randomUUID();
   }
 
   isDirty(obj: any, origObj: string): boolean {

--- a/frontend/src/app/services/csv-import.service.spec.ts
+++ b/frontend/src/app/services/csv-import.service.spec.ts
@@ -1,0 +1,54 @@
+import { CSVImportService } from './csv-import.service';
+import {RuleManagementService} from './rule-management.service'
+
+describe('CSVImportService', () => {
+  let csvImportService: CSVImportService;
+
+  it('saves rule items', (done) => {
+    const csv = "term,synonym,comment" as unknown as File;
+
+    csvImportService.import(csv, 'indexId', () => {}).then(x => {
+      expect(addRuleItem).toHaveBeenCalledOnceWith('indexId', 'term', []);
+
+      const searchInput = updateSearchInput.calls.first().args[0];
+      expect(searchInput.id).toEqual('123');
+      expect(searchInput.term).toEqual('term');
+      expect(searchInput.synonymRules.length).toEqual(1);
+      expect(searchInput.synonymRules[0].term).toEqual('synonym');
+      expect(searchInput.synonymRules[0].isActive).toEqual(true);
+      expect(searchInput.synonymRules[0].synonymType).toEqual(0);
+      expect(searchInput.isActive).toEqual(true);
+      expect(searchInput.comment).toEqual('comment');
+      done();
+    });
+  });
+
+  it('calls progress for each saved rule item', (done) => {
+    const ruleManagementService = {
+      addNewRuleItem() {},
+      updateSearchInput() {}
+    } as unknown as RuleManagementService;
+    const ctx = {progress: (percentage: number) => {}}
+    const progress = spyOn(ctx, 'progress');
+    const addRuleItem = spyOn(
+      ruleManagementService, 'addNewRuleItem'
+    ).and.returnValue(
+      Promise.resolve({returnId: '123', message: '', result: ''})
+    );
+    const updateSearchInput = spyOn(
+      ruleManagementService, 'updateSearchInput'
+    ).and.returnValue(
+      Promise.resolve({result: '', message: '', returnId: ''})
+    );
+    csvImportService = new CSVImportService(ruleManagementService);
+    const csv = "term,synonym,comment\nterm2,synonym2,comment2" as unknown as File;
+
+    csvImportService.import(csv, 'indexId', ctx.progress).then(x => {
+      expect(progress).toHaveBeenCalledTimes(2);
+      expect(progress).toHaveBeenCalledWith(50);
+      expect(progress).toHaveBeenCalledWith(100);
+      done();
+    });
+  });
+
+});

--- a/frontend/src/app/services/csv-import.service.ts
+++ b/frontend/src/app/services/csv-import.service.ts
@@ -10,7 +10,7 @@ const fileImportModal = 'file-import';
   providedIn: 'root'
 })
 export class CSVImportService {
-  constructor(private ruleManagementService: RuleManagementService, private modalService: ModalService) {}
+  constructor(private ruleManagementService: RuleManagementService) {}
 
   import(file: File, indexId: string, progress: (percentage: number) => void): Promise<ApiResult | null> {
     return new Promise((resolve, reject) => {

--- a/frontend/src/app/services/csv-import.service.ts
+++ b/frontend/src/app/services/csv-import.service.ts
@@ -1,12 +1,38 @@
+import {parse} from 'papaparse';
 import { Injectable } from '@angular/core';
+import {ApiResult} from '../models';
+import {rowsToSearchInputs} from '../lib/csv';
+import {RuleManagementService, ModalService} from '.';
 
+const fileImportModal = 'file-import';
 @Injectable({
   providedIn: 'root'
 })
 export class CSVImportService {
-  constructor() {}
+  constructor(private ruleManagementService: RuleManagementService, private modalService: ModalService) {}
 
-  import() {
-    console.log('hello');
+  import(file: File, indexId: string): Promise<ApiResult | null> {
+    return new Promise((resolve, reject) => {
+      parse(file, {
+        complete: (results: {data: string[][]}) => {
+          const searchInputs = rowsToSearchInputs(results.data);
+          const ruleCreations: Promise<ApiResult | null> = searchInputs
+            .reduce((chain: Promise<ApiResult | null>, searchInput): Promise<null | ApiResult> => {
+              return chain
+                .then(() => {
+                  return this.ruleManagementService.addNewRuleItem(indexId, searchInput.term, [])
+                    .then(inputId => {
+                      searchInput.id = inputId.returnId;
+                      return this.ruleManagementService.updateSearchInput(searchInput)
+                    });
+                });
+            }, Promise.resolve(null));
+            resolve(ruleCreations);
+        },
+        error: (err: Error) => {
+          reject(err);
+        }
+      });
+    });
   }
 }

--- a/frontend/src/app/services/csv-import.service.ts
+++ b/frontend/src/app/services/csv-import.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CSVImportService {
+  constructor() {}
+
+  import() {
+    console.log('hello');
+  }
+}

--- a/frontend/src/app/services/csv-import.service.ts
+++ b/frontend/src/app/services/csv-import.service.ts
@@ -2,7 +2,8 @@ import {parse} from 'papaparse';
 import { Injectable } from '@angular/core';
 import {ApiResult} from '../models';
 import {rowsToSearchInputs} from '../lib/csv';
-import {RuleManagementService, ModalService} from '.';
+import {RuleManagementService} from './rule-management.service'
+import {ModalService} from './modal.service';
 
 const fileImportModal = 'file-import';
 @Injectable({
@@ -11,7 +12,7 @@ const fileImportModal = 'file-import';
 export class CSVImportService {
   constructor(private ruleManagementService: RuleManagementService, private modalService: ModalService) {}
 
-  import(file: File, indexId: string, progress: () => void): Promise<ApiResult | null> {
+  import(file: File, indexId: string, progress: (percentage: number) => void): Promise<ApiResult | null> {
     return new Promise((resolve, reject) => {
       parse(file, {
         complete: (results: {data: string[][]}) => {

--- a/frontend/src/app/services/csv-import.service.ts
+++ b/frontend/src/app/services/csv-import.service.ts
@@ -11,17 +11,22 @@ const fileImportModal = 'file-import';
 export class CSVImportService {
   constructor(private ruleManagementService: RuleManagementService, private modalService: ModalService) {}
 
-  import(file: File, indexId: string): Promise<ApiResult | null> {
+  import(file: File, indexId: string, progress: () => void): Promise<ApiResult | null> {
     return new Promise((resolve, reject) => {
       parse(file, {
         complete: (results: {data: string[][]}) => {
           const searchInputs = rowsToSearchInputs(results.data);
+          let i = 1;
           const ruleCreations: Promise<ApiResult | null> = searchInputs
             .reduce((chain: Promise<ApiResult | null>, searchInput): Promise<null | ApiResult> => {
               return chain
                 .then(() => {
                   return this.ruleManagementService.addNewRuleItem(indexId, searchInput.term, [])
                     .then(inputId => {
+                      const onePercent = 100 / (searchInputs.length);
+
+                      progress(onePercent * i);
+                      i ++;
                       searchInput.id = inputId.returnId;
                       return this.ruleManagementService.updateSearchInput(searchInput)
                     });

--- a/frontend/src/app/services/index.ts
+++ b/frontend/src/app/services/index.ts
@@ -11,3 +11,4 @@ export * from './config.service';
 export * from './modal.service';
 export * from './deployment-detailed-info.service';
 export * from './preview-link.service';
+export * from './csv-import.service';

--- a/frontend/src/papaparse.d.ts
+++ b/frontend/src/papaparse.d.ts
@@ -1,0 +1,1 @@
+declare module 'papaparse';


### PR DESCRIPTION
Allow importing synonym rules from a CSV file, this saves users from having to go through the form multiple times to enter many synonyms. This implementation is very basic, it only supports synonym rules and doesn't add any tags. This can be extended if this is deemed useful.

I've used the [papaparse](https://www.papaparse.com/) package to parse the csv data.

![Screenshot From 2025-04-18 15-23-33](https://github.com/user-attachments/assets/c790c535-6c5c-4501-ab61-b1d9fe1badde)
![Screenshot From 2025-04-18 15-24-15](https://github.com/user-attachments/assets/df5d4073-4720-47ac-b6c7-2bced4defb1b)
